### PR TITLE
fix(pt/otakuanimes): Fixed images on search for pt/otakuanimes

### DIFF
--- a/src/pt/otakuanimes/build.gradle
+++ b/src/pt/otakuanimes/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'OtakuAnimes'
     extClass = '.OtakuAnimes'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/pt/otakuanimes/src/eu/kanade/tachiyomi/animeextension/pt/otakuanimes/OtakuAnimes.kt
+++ b/src/pt/otakuanimes/src/eu/kanade/tachiyomi/animeextension/pt/otakuanimes/OtakuAnimes.kt
@@ -49,7 +49,7 @@ class OtakuAnimes : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     override fun popularAnimeFromElement(element: Element) = SAnime.create().apply {
         setUrlWithoutDomain(element.attr("href"))
         title = element.selectFirst("div.aniNome")!!.text().trim()
-        thumbnail_url = element.selectFirst("img")?.attr("data-lazy-src")
+        thumbnail_url = element.selectFirst("img")?.getImageUrl()
     }
 
     override fun popularAnimeNextPageSelector() = null
@@ -111,7 +111,7 @@ class OtakuAnimes : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         return SAnime.create().apply {
             setUrlWithoutDomain(doc.location())
             title = doc.selectFirst("div.animeFirstContainer h1")!!.text()
-            thumbnail_url = doc.selectFirst("div.animeCapa img")?.attr("data-lazy-src")
+            thumbnail_url = doc.selectFirst("div.animeCapa img")?.getImageUrl()
             description = doc.selectFirst("div.animeSecondContainer > p")?.text()
             genre = doc.select("ul.animeGen li").eachText()?.joinToString(", ")
         }
@@ -220,6 +220,19 @@ class OtakuAnimes : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         }
 
         return document
+    }
+
+    /**
+     * Tries to get the image url via various possible attributes.
+     * Taken from Tachiyomi's Madara multisrc.
+     */
+    protected open fun Element.getImageUrl(): String? {
+        return when {
+            hasAttr("data-src") -> attr("abs:data-src")
+            hasAttr("data-lazy-src") -> attr("abs:data-lazy-src")
+            hasAttr("srcset") -> attr("abs:srcset").substringBefore(" ")
+            else -> attr("abs:src")
+        }.substringBefore("?resize")
     }
 
     companion object {


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format
