### PR TITLE
fix(all/torrentioanime): Fix fetching episode list

### DIFF
--- a/src/all/torrentioanime/build.gradle
+++ b/src/all/torrentioanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Torrentio Anime (Torrent / Debrid)'
     extClass = '.Torrentio'
-    extVersionCode = 7
+    extVersionCode = 8
     containsNsfw = false
 }
 

--- a/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/Torrentio.kt
+++ b/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/Torrentio.kt
@@ -29,9 +29,11 @@ import kotlinx.serialization.json.Json
 import okhttp3.FormBody
 import okhttp3.Request
 import okhttp3.Response
+import org.json.JSONObject
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
+import java.net.URL
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -358,7 +360,9 @@ class Torrentio : ConfigurableAnimeSource, AnimeHttpSource() {
 
     // ============================== Episodes ==============================
     override fun episodeListRequest(anime: SAnime): Request {
-        return GET("https://anime-kitsu.strem.fun/meta/series/anilist%3A${anime.url}.json")
+        val res = URL("https://api.ani.zip/mappings?anilist_id=${anime.url}").readText()
+        val kitsuId = JSONObject(res).getJSONObject("mappings").getInt("kitsu_id").toString()
+        return GET("https://anime-kitsu.strem.fun/meta/series/kitsu%3A$kitsuId.json")
     }
 
     override fun episodeListParse(response: Response): List<SEpisode> {


### PR DESCRIPTION
The episode list for the wrong anime was returned by the old url. This patch fixes that by specifically using the kitsu id instead.

Demo (at the time of this PR):

Actual Anilist ID: 166531
Corresponding Kitsu ID: 47659

Wrong metadata: <https://anime-kitsu.strem.fun/meta/series/anilist%3A166531.json>
Correct metadata: <https://anime-kitsu.strem.fun/meta/series/kitsu%3A47659.json>

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

