### PR TITLE
fix(deps): change dependency inorichi.injekt to mihonapp:injekt

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,11 +19,11 @@ kotlin-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", ver
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines_version" }
 coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines_version" }
 
-injekt-core = { module = "com.github.inorichi.injekt:injekt-core", version = "65b0440" }
+injekt = "com.github.mihonapp:injekt:91edab2317"
 rxjava = { module = "io.reactivex:rxjava", version = "1.3.8" }
 jsoup = { module = "org.jsoup:jsoup", version = "1.16.1" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version = "5.0.0-alpha.11" }
 quickjs = { module = "app.cash.quickjs:quickjs-android", version = "0.9.2" }
 
 [bundles]
-common = ["kotlin-stdlib", "injekt-core", "rxjava", "kotlin-protobuf", "kotlin-json", "jsoup", "okhttp", "aniyomi-lib", "quickjs", "coroutines-core", "coroutines-android"]
+common = ["kotlin-stdlib", "injekt", "rxjava", "kotlin-protobuf", "kotlin-json", "jsoup", "okhttp", "aniyomi-lib", "quickjs", "coroutines-core", "coroutines-android"]


### PR DESCRIPTION
I have posted this issue on aniyomi [Ref](https://github.com/aniyomiorg/aniyomi/issues/1776)
and to fix the problem [Ref](https://github.com/mihonapp/mihon/commit/83fd4746eda1b99f35292b0c2211e606a421b3eb)

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format
