### PR TITLE
fix(pt/Anitube): Added option to disable File4Go mirror

### DIFF
--- a/src/pt/anitube/build.gradle
+++ b/src/pt/anitube/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anitube'
     extClass = '.Anitube'
-    extVersionCode = 19
+    extVersionCode = 20
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/anitube/src/eu/kanade/tachiyomi/animeextension/pt/anitube/Anitube.kt
+++ b/src/pt/anitube/src/eu/kanade/tachiyomi/animeextension/pt/anitube/Anitube.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.animeextension.pt.anitube.extractors.AnitubeDownloadExtractor
 import eu.kanade.tachiyomi.animeextension.pt.anitube.extractors.AnitubeExtractor
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
@@ -199,8 +200,10 @@ class Anitube : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
         val links = mutableListOf(document.location())
 
-        document.selectFirst("div.abaItemDown > a")?.attr("href")?.let {
-            links.add(it)
+        if (preferences.getBoolean(PREF_FILE4GO_KEY, PREF_FILE4GO_DEFAULT)!!) {
+            document.selectFirst("div.abaItemDown > a")?.attr("href")?.let {
+                links.add(it)
+            }
         }
 
         val epName = document.selectFirst("meta[itemprop=name]")!!.attr("content")
@@ -232,6 +235,16 @@ class Anitube : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                 val index = findIndexOfValue(selected)
                 val entry = entryValues[index] as String
                 preferences.edit().putString(key, entry).commit()
+            }
+        }.also(screen::addPreference)
+
+        SwitchPreferenceCompat(screen.context).apply {
+            key = PREF_FILE4GO_KEY
+            title = "Usar File4Go como mirror"
+            setDefaultValue(PREF_FILE4GO_DEFAULT)
+            summary = PREF_FILE4GO_SUMMARY
+            setOnPreferenceChangeListener { _, newValue ->
+                preferences.edit().putBoolean(key, newValue as Boolean).commit()
             }
         }.also(screen::addPreference)
 
@@ -308,6 +321,9 @@ class Anitube : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         private const val PREF_AUTHCODE_KEY = "authcode"
         private const val PREF_AUTHCODE_SUMMARY = "Código de Autenticação"
         private const val PREF_AUTHCODE_DEFAULT = ""
+        private const val PREF_FILE4GO_KEY = "file4go"
+        private const val PREF_FILE4GO_SUMMARY = "Usar File4Go como mirror"
+        private const val PREF_FILE4GO_DEFAULT = false
         private const val PREF_QUALITY_KEY = "preferred_quality"
         private const val PREF_QUALITY_TITLE = "Qualidade preferida"
         private const val PREF_QUALITY_DEFAULT = "HD"


### PR DESCRIPTION
Sometimes, the file4go have a strong cloudflare protection.

With disabled option, the fetch videos vill be faster.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format
