### PR TITLE
Xfani：add new preference to ignore ssl verify issue.

### DIFF
--- a/src/zh/xfani/build.gradle
+++ b/src/zh/xfani/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Xfani'
     extClass = '.Xfani'
-    extVersionCode = 1
+    extVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/zh/xfani/src/eu/kanade/tachiyomi/animeextension/zh/xfani/Xfani.kt
+++ b/src/zh/xfani/src/eu/kanade/tachiyomi/animeextension/zh/xfani/Xfani.kt
@@ -3,8 +3,10 @@ package eu.kanade.tachiyomi.animeextension.zh.xfani
 import android.annotation.SuppressLint
 import android.app.Application
 import android.content.SharedPreferences
+import android.widget.Toast
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -20,6 +22,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Interceptor
 import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -30,6 +33,7 @@ import uy.kohesive.injekt.injectLazy
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLHandshakeException
 import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
 
@@ -71,10 +75,22 @@ class Xfani : AnimeHttpSource(), ConfigurableAnimeSource {
     }
 
     override val client: OkHttpClient
-        get() = network.client.newBuilder().ignoreAllSSLErrors().build()
+        get() = if (preferences.getBoolean(PREF_KEY_IGNORE_SSL_ERROR, false)) {
+            network.client.newBuilder().ignoreAllSSLErrors().build()
+        } else {
+            network.client.newBuilder().addInterceptor(::checkSSLErrorInterceptor).build()
+        }
 
     private val selectedVideoSource
         get() = preferences.getString(PREF_KEY_VIDEO_SOURCE, DEFAULT_VIDEO_SOURCE)!!.toInt()
+
+    private fun checkSSLErrorInterceptor(chain: Interceptor.Chain): Response {
+        try {
+            return chain.proceed(chain.request())
+        } catch (e: SSLHandshakeException) {
+            throw SSLHandshakeException("SSL证书验证异常，可以尝试在设置中忽略SSL验证问题。")
+        }
+    }
 
     override fun animeDetailsParse(response: Response): SAnime {
         val jsoup = response.asJsoup()
@@ -221,24 +237,38 @@ class Xfani : AnimeHttpSource(), ConfigurableAnimeSource {
     }
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        screen.addPreference(
-            ListPreference(screen.context).apply {
-                key = PREF_KEY_VIDEO_SOURCE
-                title = "请设置首选视频源线路"
-                entries = arrayOf("主线-1", "主线-2", "备用-1")
-                entryValues = arrayOf("0", "1", "2")
-                setDefaultValue(DEFAULT_VIDEO_SOURCE)
-                summary = "当前选择：${entries[selectedVideoSource]}"
-                setOnPreferenceChangeListener { _, newValue ->
-                    summary = "当前选择 ${entries[(newValue as String).toInt()]}"
-                    true
-                }
-            },
-        )
+        screen.apply {
+            addPreference(
+                ListPreference(screen.context).apply {
+                    key = PREF_KEY_VIDEO_SOURCE
+                    title = "请设置首选视频源线路"
+                    entries = arrayOf("主线-1", "主线-2", "备用-1")
+                    entryValues = arrayOf("0", "1", "2")
+                    setDefaultValue(DEFAULT_VIDEO_SOURCE)
+                    summary = "当前选择：${entries[selectedVideoSource]}"
+                    setOnPreferenceChangeListener { _, newValue ->
+                        summary = "当前选择 ${entries[(newValue as String).toInt()]}"
+                        true
+                    }
+                },
+            )
+            addPreference(
+                SwitchPreferenceCompat(screen.context).apply {
+                    key = PREF_KEY_IGNORE_SSL_ERROR
+                    title = "忽略SSL证书校验"
+                    setDefaultValue(false)
+                    setOnPreferenceChangeListener { _, _ ->
+                        Toast.makeText(screen.context, "重启应用后生效", Toast.LENGTH_SHORT).show()
+                        true
+                    }
+                },
+            )
+        }
     }
 
     companion object {
         const val PREF_KEY_VIDEO_SOURCE = "PREF_KEY_VIDEO_SOURCE"
+        const val PREF_KEY_IGNORE_SSL_ERROR = "PREF_KEY_IGNORE_SSL_ERROR"
 
         const val DEFAULT_VIDEO_SOURCE = "0"
 

--- a/src/zh/xfani/src/eu/kanade/tachiyomi/animeextension/zh/xfani/Xfani.kt
+++ b/src/zh/xfani/src/eu/kanade/tachiyomi/animeextension/zh/xfani/Xfani.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.animeextension.zh.xfani
 
+import android.annotation.SuppressLint
 import android.app.Application
 import android.content.SharedPreferences
 import androidx.preference.ListPreference
@@ -20,11 +21,17 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MultipartBody
+import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
 
 class Xfani : AnimeHttpSource(), ConfigurableAnimeSource {
     override val baseUrl: String
@@ -41,11 +48,41 @@ class Xfani : AnimeHttpSource(), ConfigurableAnimeSource {
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
     }
     private val numberRegex = Regex("\\d+")
+    private fun OkHttpClient.Builder.ignoreAllSSLErrors(): OkHttpClient.Builder {
+        val naiveTrustManager =
+            @SuppressLint("CustomX509TrustManager")
+            object : X509TrustManager {
+                override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+                override fun checkClientTrusted(certs: Array<X509Certificate>, authType: String) =
+                    Unit
+
+                override fun checkServerTrusted(certs: Array<X509Certificate>, authType: String) =
+                    Unit
+            }
+
+        val insecureSocketFactory = SSLContext.getInstance("TLSv1.2").apply {
+            val trustAllCerts = arrayOf<TrustManager>(naiveTrustManager)
+            init(null, trustAllCerts, SecureRandom())
+        }.socketFactory
+
+        sslSocketFactory(insecureSocketFactory, naiveTrustManager)
+        hostnameVerifier { _, _ -> true }
+        return this
+    }
+
+    override val client: OkHttpClient
+        get() = network.client.newBuilder().ignoreAllSSLErrors().build()
 
     private val selectedVideoSource
         get() = preferences.getString(PREF_KEY_VIDEO_SOURCE, DEFAULT_VIDEO_SOURCE)!!.toInt()
 
-    override fun animeDetailsParse(response: Response): SAnime = SAnime.create()
+    override fun animeDetailsParse(response: Response): SAnime {
+        val jsoup = response.asJsoup()
+        return SAnime.create().apply {
+            description = jsoup.select("#height_limit.text").text()
+            title = jsoup.select(".slide-info-title").text()
+        }
+    }
 
     override fun episodeListParse(response: Response): List<SEpisode> {
         val jsoup = response.asJsoup()
@@ -61,7 +98,7 @@ class Xfani : AnimeHttpSource(), ConfigurableAnimeSource {
                 url = it.attr("href")
                 episode_number = numberRegex.find(name)?.value?.toFloat() ?: -1F
             }
-        }
+        }.sortedByDescending { it.episode_number }
     }
 
     override fun videoListParse(response: Response): List<Video> {
@@ -92,9 +129,9 @@ class Xfani : AnimeHttpSource(), ConfigurableAnimeSource {
                 url = "/bangumi/${it.vodId}.html"
                 thumbnail_url = it.vodPicThumb.ifEmpty { it.vodPic }
                 title = it.vodName
-                author = it.vodActor
+                author = it.vodActor.replace(",,,", "")
                 description = it.vodBlurb
-                genre = it.vodClass
+                genre = it.vodClass.replace(",", ", ")
             }
         }
         return AnimesPage(


### PR DESCRIPTION
After the website updated its SSL certificate, there are certificate verification issues on mobile devices. Add an option to ignore SSL verification.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [x] Have made sure all the icons are in png format
