### PR TITLE
Ignore episodes without video list

### DIFF
--- a/src/all/torrentioanime/build.gradle
+++ b/src/all/torrentioanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Torrentio Anime (Torrent / Debrid)'
     extClass = '.Torrentio'
-    extVersionCode = 9
+    extVersionCode = 10
     containsNsfw = false
 }
 

--- a/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/Torrentio.kt
+++ b/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/Torrentio.kt
@@ -375,6 +375,7 @@ class Torrentio : ConfigurableAnimeSource, AnimeHttpSource() {
                     ?.let { videos ->
                         if (preferences.getBoolean(UPCOMING_EP_KEY, UPCOMING_EP_DEFAULT)) { videos } else { videos.filter { video -> (video.released?.let { parseDate(it) } ?: 0L) <= System.currentTimeMillis() } }
                     }
+                    ?.filter { it.thumbnail != null }
                     ?.map { video ->
                         SEpisode.create().apply {
                             episode_number = video.episode?.toFloat() ?: 0.0F

--- a/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/dto/TorrentioDto.kt
+++ b/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/dto/TorrentioDto.kt
@@ -150,4 +150,5 @@ data class EpisodeVideo(
     val episode: Int? = null,
     val released: String? = null,
     val title: String? = null,
+    val thumbnail: String? = null,
 )


### PR DESCRIPTION
This patch makes the extension ignore episodes that are in the URL but still unreleased.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format
