### PR TITLE
Fix DramaCool source

### DIFF
--- a/src/en/dramacool/build.gradle
+++ b/src/en/dramacool/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'DramaCool'
     extClass = '.DramaCool'
-    extVersionCode = 50
+    extVersionCode = 51
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/dramacool/src/eu/kanade/tachiyomi/animeextension/en/dramacool/DramaCool.kt
+++ b/src/en/dramacool/src/eu/kanade/tachiyomi/animeextension/en/dramacool/DramaCool.kt
@@ -29,7 +29,7 @@ class DramaCool : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     // TODO: Check frequency of url changes to potentially
     // add back overridable baseurl preference
-    override val baseUrl = "https://asianc.sh/"
+    override val baseUrl = "https://asianc.co/"
 
     override val lang = "en"
 


### PR DESCRIPTION
Close #385 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format
