### PR TITLE
Fix HiAnime pref quality

### DIFF
--- a/lib-multisrc/zorotheme/build.gradle.kts
+++ b/lib-multisrc/zorotheme/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 3
+baseVersionCode = 4
 
 dependencies {
     api(project(":lib:megacloud-extractor"))

--- a/lib-multisrc/zorotheme/src/eu/kanade/tachiyomi/multisrc/zorotheme/ZoroTheme.kt
+++ b/lib-multisrc/zorotheme/src/eu/kanade/tachiyomi/multisrc/zorotheme/ZoroTheme.kt
@@ -48,7 +48,7 @@ abstract class ZoroTheme(
             .clearOldHosts()
     }
 
-    private val docHeaders = headers.newBuilder().apply {
+    protected val docHeaders = headers.newBuilder().apply {
         add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
         add("Host", baseUrl.toHttpUrl().host)
         add("Referer", "$baseUrl/")

--- a/lib-multisrc/zorotheme/src/eu/kanade/tachiyomi/multisrc/zorotheme/ZoroTheme.kt
+++ b/lib-multisrc/zorotheme/src/eu/kanade/tachiyomi/multisrc/zorotheme/ZoroTheme.kt
@@ -236,6 +236,7 @@ abstract class ZoroTheme(
         }.flatten()
 
         return embedLinks.parallelCatchingFlatMap(::extractVideo)
+            .sort()
     }
 
     abstract fun extractVideo(server: VideoData): List<Video>

--- a/src/en/zoro/build.gradle
+++ b/src/en/zoro/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.HiAnime'
     themePkg = 'zorotheme'
     baseUrl = 'https://hianime.to'
-    overrideVersionCode = 41
+    overrideVersionCode = 42
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/zoro/build.gradle
+++ b/src/en/zoro/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.HiAnime'
     themePkg = 'zorotheme'
     baseUrl = 'https://hianime.to'
-    overrideVersionCode = 42
+    overrideVersionCode = 43
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
+++ b/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
@@ -4,6 +4,8 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.lib.megacloudextractor.MegaCloudExtractor
 import eu.kanade.tachiyomi.lib.streamtapeextractor.StreamTapeExtractor
 import eu.kanade.tachiyomi.multisrc.zorotheme.ZoroTheme
+import eu.kanade.tachiyomi.network.GET
+import okhttp3.Request
 
 class HiAnime : ZoroTheme(
     "en",
@@ -21,6 +23,8 @@ class HiAnime : ZoroTheme(
 
     private val streamtapeExtractor by lazy { StreamTapeExtractor(client) }
     private val megaCloudExtractor by lazy { MegaCloudExtractor(client, headers, preferences) }
+
+    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/recently-updated?page=$page", docHeaders)
 
     override fun extractVideo(server: VideoData): List<Video> {
         return when (server.name) {


### PR DESCRIPTION
Close #380 

Tested on kaido too as both use ZoroTheme, though I don't see any issue reported for it.

Also override ZoroTheme's default endpoint for latest update in HiAnime from `/top-airing` into `/recently-updated`, which is more appropriate. Kaido will keep using the default in case others preferred that.

Checklist:
- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format
