### PR TITLE
fix(all/hiraki): Partial fix for Hikari source

### DIFF
--- a/src/all/hikari/build.gradle
+++ b/src/all/hikari/build.gradle
@@ -1,13 +1,14 @@
 ext {
     extName = 'Hikari'
     extClass = '.Hikari'
-    extVersionCode = 11
+    extVersionCode = 12
 }
 
 apply from: "$rootDir/common.gradle"
 
 dependencies {
-    implementation(project(':lib:filemoon-extractor'))
-    implementation(project(':lib:vidhide-extractor'))
     implementation(project(':lib:chillx-extractor'))
+    implementation(project(':lib:filemoon-extractor'))
+    implementation(project(':lib:streamwish-extractor'))
+    implementation(project(':lib:vidhide-extractor'))
 }


### PR DESCRIPTION
The main problem is the Chillx extractor, that doesn't work.

The sollution is return the result of others extractors.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format
