### PR TITLE
Xfani: Fix video list parse

### DIFF
--- a/src/zh/xfani/build.gradle
+++ b/src/zh/xfani/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Xfani'
     extClass = '.Xfani'
-    extVersionCode = 3
+    extVersionCode = 4
 }
 
 apply from: "$rootDir/common.gradle"


### PR DESCRIPTION
Due to the possibility of inconsistent episode counts across different server, it has been modified to first match based on names and allowing for the presence of missing entries.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] Have made sure all the icons are in png format
