### PR TITLE
fix(lib/VidGuardExtractor): Increase stack size to 8MB

### DIFF
--- a/lib/vidguard-extractor/src/main/java/eu/kanade/tachiyomi/lib/vidguardextractor/VidGuardExtractor.kt
+++ b/lib/vidguard-extractor/src/main/java/eu/kanade/tachiyomi/lib/vidguardextractor/VidGuardExtractor.kt
@@ -84,12 +84,12 @@ class VidGuardExtractor(private val client: OkHttpClient) {
                     Context.toString(svgObject)
                 }
             } catch (e: Exception) {
-                Log.i("Error", e.toString())
+                Log.e("Error", "JavaScript execution error: ${e.message}")
             } finally {
                 Context.exit()
             }
         }
-        val t = Thread(ThreadGroup("A"), r, "thread_rhino", 2000000) // StackSize 2Mb: Run in a thread because rhino requires more stack size for large scripts.
+        val t = Thread(ThreadGroup("A"), r, "thread_rhino", 8 * 1024 * 1024) // Increase stack size to 8MB
         t.start()
         t.join()
         t.interrupt()


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format
