### PR TITLE
feat(en/aniplay): new provider pahe implemented (somewhat)

### DIFF
--- a/src/en/aniplay/build.gradle
+++ b/src/en/aniplay/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'AniPlay'
     extClass = '.AniPlay'
     themePkg = 'anilist'
-    overrideVersionCode = 7
+    overrideVersionCode = 8
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/aniplay/src/eu/kanade/tachiyomi/animeextension/en/aniplay/AniPlayDto.kt
+++ b/src/en/aniplay/src/eu/kanade/tachiyomi/animeextension/en/aniplay/AniPlayDto.kt
@@ -21,6 +21,14 @@ data class EpisodeListResponse(
     )
 }
 
+// Provider else
+@Serializable
+data class EpisodeData(
+    val source: String,
+    val language: String,
+    val response: VideoSourceResponse,
+)
+
 @Serializable
 data class VideoSourceResponse(
     val sources: List<Source>?,
@@ -38,6 +46,14 @@ data class VideoSourceResponse(
         val lang: String?,
     )
 }
+
+// Provider Yuki
+@Serializable
+data class EpisodeDataYuki(
+    val source: String,
+    val language: String,
+    val response: VideoSourceResponseYuki,
+)
 
 @Serializable
 data class VideoSourceResponseYuki(
@@ -61,24 +77,55 @@ data class VideoSourceResponseYuki(
     )
 }
 
+// Provider Pahe
+@Serializable
+data class EpisodeDataPahe(
+    val source: String,
+    val language: String,
+    val response: VideoSourceResponsePahe,
+)
+
+@Serializable
+data class VideoSourceResponsePahe(
+    val sources: List<Source>?,
+    val audio: List<Audio>?,
+    val intro: Timestamp?,
+    val outro: Timestamp?,
+    val subtitles: List<Subtitle>?,
+
+) {
+    @Serializable
+    data class Source(
+        val url: String,
+        val quality: String?,
+    )
+
+    @Serializable
+    data class Audio(
+        val file: String,
+        val label: String?,
+        val kind: String?,
+        val default: Boolean?,
+    )
+
+    @Serializable
+    data class Timestamp(
+        val start: Int?,
+        val end: Int?,
+    )
+
+    @Serializable
+    data class Subtitle(
+        val url: String?,
+        val lang: String?,
+    )
+}
+
+// Extra
 @Serializable
 data class EpisodeExtra(
     val source: String,
     val episodeNum: Float,
     val episodeId: String,
     val hasDub: Boolean,
-)
-
-@Serializable
-data class EpisodeData(
-    val source: String,
-    val language: String,
-    val response: VideoSourceResponse,
-)
-
-@Serializable
-data class EpisodeDataYuki(
-    val source: String,
-    val language: String,
-    val response: VideoSourceResponseYuki,
 )


### PR DESCRIPTION
Checklist:
Closes #588

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] ~Added the `isNsfw = true` flag in `build.gradle` when appropriate~
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [x] Have made sure all the icons are in png format

Pahe provider videos shows as "Video" quality.
This is from 
```
return playlistUtils.extractFromHls(
  playlistUrl = defaultSource.url,
  videoNameGen = { quality -> "$serverName - $quality - $typeName" },
  subtitleList = subtitles,
)
```
and I kind of dont care. It works.
![Screenshot_2025-01-25-22-33-25-653_xyz jmir tachiyomi mi debug (Small)](https://github.com/user-attachments/assets/09db026e-8513-4a4a-9717-f6b8fbe46a04)
