### PR TITLE
[skip CI] using version catalog for jsunpacker

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ rxjava = { module = "io.reactivex:rxjava", version = "1.3.8" }
 jsoup = { module = "org.jsoup:jsoup", version = "1.16.1" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version = "5.0.0-alpha.11" }
 quickjs = { module = "app.cash.quickjs:quickjs-android", version = "0.9.2" }
+jsunpacker = { module = "dev.datlag.jsunpacker:jsunpacker", version = "1.0.1" }
 
 [bundles]
 common = ["kotlin-stdlib", "injekt", "rxjava", "kotlin-protobuf", "kotlin-json", "jsoup", "okhttp", "aniyomi-lib", "quickjs", "coroutines-core", "coroutines-android"]

--- a/lib/fastream-extractor/build.gradle.kts
+++ b/lib/fastream-extractor/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation("dev.datlag.jsunpacker:jsunpacker:1.0.1") {
+    implementation(libs.jsunpacker) {
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
     }
     implementation(project(":lib:playlist-utils"))

--- a/lib/filemoon-extractor/build.gradle.kts
+++ b/lib/filemoon-extractor/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation("dev.datlag.jsunpacker:jsunpacker:1.0.1") {
+    implementation(libs.jsunpacker) {
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
     }
     implementation(project(":lib:playlist-utils"))

--- a/lib/fireplayer-extractor/build.gradle.kts
+++ b/lib/fireplayer-extractor/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation("dev.datlag.jsunpacker:jsunpacker:1.0.1") {
+    implementation(libs.jsunpacker) {
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
     }
     implementation(project(":lib:playlist-utils"))

--- a/lib/mp4upload-extractor/build.gradle.kts
+++ b/lib/mp4upload-extractor/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation("dev.datlag.jsunpacker:jsunpacker:1.0.1") {
+    implementation(libs.jsunpacker) {
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
     }
 }

--- a/lib/streamhidevid-extractor/build.gradle.kts
+++ b/lib/streamhidevid-extractor/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation(project(":lib:playlist-utils"))
-    implementation("dev.datlag.jsunpacker:jsunpacker:1.0.1") {
+    implementation(libs.jsunpacker) {
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
     }
 }

--- a/lib/streamvid-extractor/build.gradle.kts
+++ b/lib/streamvid-extractor/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation(project(":lib:playlist-utils"))
-    implementation("dev.datlag.jsunpacker:jsunpacker:1.0.1") {
+    implementation(libs.jsunpacker) {
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
     }
 }

--- a/lib/streamwish-extractor/build.gradle.kts
+++ b/lib/streamwish-extractor/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation("dev.datlag.jsunpacker:jsunpacker:1.0.1") {
+    implementation(libs.jsunpacker) {
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
     }
     implementation(project(":lib:playlist-utils"))

--- a/lib/upstream-extractor/build.gradle.kts
+++ b/lib/upstream-extractor/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation(project(":lib:playlist-utils"))
-    implementation("dev.datlag.jsunpacker:jsunpacker:1.0.1") {
+    implementation(libs.jsunpacker) {
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
     }
 }

--- a/lib/vido-extractor/build.gradle.kts
+++ b/lib/vido-extractor/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation(project(":lib:playlist-utils"))
-    implementation("dev.datlag.jsunpacker:jsunpacker:1.0.1") {
+    implementation(libs.jsunpacker) {
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
     }
 }

--- a/src/all/animexin/build.gradle
+++ b/src/all/animexin/build.gradle
@@ -13,5 +13,5 @@ dependencies {
     implementation(project(':lib:okru-extractor'))
     implementation(project(':lib:gdriveplayer-extractor'))
     implementation(project(':lib:dood-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/all/javguru/build.gradle
+++ b/src/all/javguru/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation(project(':lib:streamtape-extractor'))
     implementation(project(':lib:dood-extractor'))
     implementation(project(':lib:mixdrop-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
     implementation(project(':lib:playlist-utils'))
     implementation(project(':lib:javcoverfetcher'))
 }

--- a/src/ar/anime4up/build.gradle
+++ b/src/ar/anime4up/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     implementation(project(':lib:uqload-extractor'))
     implementation(project(':lib:vidbom-extractor'))
     implementation(project(':lib:voe-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/ar/tuktukcinema/build.gradle
+++ b/src/ar/tuktukcinema/build.gradle
@@ -13,5 +13,5 @@ dependencies {
     implementation(project(':lib:streamtape-extractor'))
     implementation(project(':lib:vidbom-extractor'))
     implementation(project(':lib:playlist-utils'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/de/animebase/build.gradle
+++ b/src/de/animebase/build.gradle
@@ -12,5 +12,5 @@ dependencies {
     implementation(project(":lib:streamwish-extractor"))
     implementation(project(":lib:vidguard-extractor"))
     implementation(project(":lib:playlist-utils"))
-    implementation("dev.datlag.jsunpacker:jsunpacker:1.0.1")
+    implementation(libs.jsunpacker)
 }

--- a/src/de/cineclix/build.gradle
+++ b/src/de/cineclix/build.gradle
@@ -12,5 +12,5 @@ dependencies {
     implementation(project(':lib:dood-extractor'))
     implementation(project(':lib:voe-extractor'))
     implementation(project(':lib:playlist-utils'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/de/einfach/build.gradle
+++ b/src/de/einfach/build.gradle
@@ -14,5 +14,5 @@ dependencies {
     implementation(project(":lib:streamtape-extractor"))
     implementation(project(":lib:streamwish-extractor"))
     implementation(project(":lib:voe-extractor"))
-    implementation("dev.datlag.jsunpacker:jsunpacker:1.0.1")
+    implementation(libs.jsunpacker)
 }

--- a/src/de/moflixstream/build.gradle
+++ b/src/de/moflixstream/build.gradle
@@ -12,5 +12,5 @@ dependencies {
     implementation(project(':lib:streamtape-extractor'))
     implementation(project(':lib:vidguard-extractor'))
     implementation(project(':lib:playlist-utils'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/de/movie2k/build.gradle
+++ b/src/de/movie2k/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     implementation(project(':lib:dood-extractor'))
     implementation(project(':lib:streamtape-extractor'))
     implementation(project(':lib:mixdrop-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/en/allanime/build.gradle
+++ b/src/en/allanime/build.gradle
@@ -14,5 +14,5 @@ dependencies {
     implementation(project(':lib:gogostream-extractor'))
     implementation(project(':lib:filemoon-extractor'))
     implementation(project(':lib:streamwish-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/en/animekhor/build.gradle
+++ b/src/en/animekhor/build.gradle
@@ -11,5 +11,5 @@ apply from: "$rootDir/common.gradle"
 dependencies {
     implementation(project(':lib:okru-extractor'))
     implementation(project(':lib:streamwish-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/en/animenosub/build.gradle
+++ b/src/en/animenosub/build.gradle
@@ -12,5 +12,5 @@ apply from: "$rootDir/common.gradle"
 dependencies {
     implementation(project(':lib:filemoon-extractor'))
     implementation(project(':lib:streamwish-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -7,5 +7,5 @@ ext {
 apply from: "$rootDir/common.gradle"
 
 dependencies {
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/en/ask4movie/build.gradle
+++ b/src/en/ask4movie/build.gradle
@@ -8,5 +8,5 @@ apply from: "$rootDir/common.gradle"
 
 dependencies {
     implementation(project(':lib:filemoon-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/en/kissanime/build.gradle
+++ b/src/en/kissanime/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     implementation(project(':lib:dailymotion-extractor'))
     implementation(project(':lib:mp4upload-extractor'))
     implementation(project(':lib:yourupload-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/en/multimovies/build.gradle
+++ b/src/en/multimovies/build.gradle
@@ -14,5 +14,5 @@ dependencies {
     implementation(project(':lib:dood-extractor'))
     implementation(project(':lib:mixdrop-extractor'))
     implementation(project(':lib:cryptoaes'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/en/myanime/build.gradle
+++ b/src/en/myanime/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     implementation(project(':lib:dailymotion-extractor'))
     implementation(project(':lib:gdriveplayer-extractor'))
     implementation(project(':lib:okru-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/es/cuevana/build.gradle
+++ b/src/es/cuevana/build.gradle
@@ -22,5 +22,5 @@ dependencies {
     implementation(project(':lib:burstcloud-extractor'))
     implementation(project(':lib:fastream-extractor'))
     implementation(project(':lib:upstream-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/es/katanime/build.gradle
+++ b/src/es/katanime/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     implementation(project(':lib:mp4upload-extractor'))
     implementation(project(':lib:dood-extractor'))
     implementation(project(':lib:playlist-utils'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/es/latanime/build.gradle
+++ b/src/es/latanime/build.gradle
@@ -12,5 +12,5 @@ dependencies {
     implementation(project(':lib:yourupload-extractor'))
     implementation(project(':lib:okru-extractor'))
     implementation(project(':lib:dood-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/es/pelisplushd/build.gradle
+++ b/src/es/pelisplushd/build.gradle
@@ -25,5 +25,5 @@ dependencies {
     implementation(project(':lib:streamhidevid-extractor'))
     implementation(project(':lib:streamsilk-extractor'))
     implementation(project(':lib:vidguard-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/fr/jetanime/build.gradle
+++ b/src/fr/jetanime/build.gradle
@@ -9,6 +9,6 @@ ext {
 apply from: "$rootDir/common.gradle"
 
 dependencies {
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
     implementation(project(':lib:playlist-utils'))
 }

--- a/src/fr/otakufr/build.gradle
+++ b/src/fr/otakufr/build.gradle
@@ -14,5 +14,5 @@ dependencies {
     implementation(project(':lib:dood-extractor'))
     implementation(project(':lib:okru-extractor'))
     implementation(project(":lib:playlist-utils"))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/hi/yomovies/build.gradle
+++ b/src/hi/yomovies/build.gradle
@@ -10,6 +10,6 @@ apply from: "$rootDir/common.gradle"
 dependencies {
     implementation(project(':lib:dood-extractor'))
     implementation(project(':lib:mixdrop-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
     implementation(project(':lib:playlist-utils'))
 }

--- a/src/id/kuronime/build.gradle
+++ b/src/id/kuronime/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     implementation(project(':lib:streamlare-extractor'))
     implementation(project(':lib:mp4upload-extractor'))
     implementation(project(':lib:yourupload-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/id/neonime/build.gradle
+++ b/src/id/neonime/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     implementation(project(':lib:gdriveplayer-extractor'))
     implementation(project(':lib:yourupload-extractor'))
     implementation(project(':lib:okru-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/id/nimegami/build.gradle
+++ b/src/id/nimegami/build.gradle
@@ -7,6 +7,6 @@ ext {
 apply from: "$rootDir/common.gradle"
 
 dependencies {
-    implementation("dev.datlag.jsunpacker:jsunpacker:1.0.1")
+    implementation(libs.jsunpacker)
     implementation(project(":lib:synchrony"))
 }

--- a/src/it/animeworld/build.gradle
+++ b/src/it/animeworld/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     implementation(project(':lib:dood-extractor'))
     implementation(project(':lib:streamhidevid-extractor'))
     implementation(project(':lib:vidguard-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/it/toonitalia/build.gradle
+++ b/src/it/toonitalia/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     implementation(project(':lib:voe-extractor'))
     implementation(project(':lib:streamtape-extractor'))
     implementation(project(':lib:playlist-utils'))
-    implementation("dev.datlag.jsunpacker:jsunpacker:1.0.1")
+    implementation(libs.jsunpacker)
 }

--- a/src/pl/wbijam/build.gradle
+++ b/src/pl/wbijam/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     implementation(project(':lib:dailymotion-extractor'))
     implementation(project(':lib:mp4upload-extractor'))
     implementation(project(':lib:sibnet-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/pt/animesbr/build.gradle
+++ b/src/pt/animesbr/build.gradle
@@ -10,6 +10,6 @@ ext {
 apply from: "$rootDir/common.gradle"
 
 dependencies {
-    implementation("dev.datlag.jsunpacker:jsunpacker:1.0.1")
+    implementation(libs.jsunpacker)
     implementation(project(":lib:vidmoly-extractor"))
 }

--- a/src/pt/doramogo/build.gradle
+++ b/src/pt/doramogo/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     implementation(project(":lib:googledrive-extractor"))
     implementation(project(":lib:okru-extractor"))
     implementation(project(":lib:playlist-utils"))
-    implementation("dev.datlag.jsunpacker:jsunpacker:1.0.1")
+    implementation(libs.jsunpacker)
 }

--- a/src/pt/megaflix/build.gradle
+++ b/src/pt/megaflix/build.gradle
@@ -16,5 +16,5 @@ dependencies {
     implementation(project(":lib:streamwish-extractor"))
     implementation(project(":lib:playlist-utils"))
     // for mixdrop and megaflix
-    implementation("dev.datlag.jsunpacker:jsunpacker:1.0.1")
+    implementation(libs.jsunpacker)
 }

--- a/src/pt/pobreflix/build.gradle
+++ b/src/pt/pobreflix/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     implementation(project(":lib:streamwish-extractor"))
     implementation(project(":lib:streamtape-extractor"))
     implementation(project(":lib:playlist-utils"))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/pt/vizer/build.gradle
+++ b/src/pt/vizer/build.gradle
@@ -12,5 +12,5 @@ dependencies {
     implementation(project(':lib:mixdrop-extractor'))
     implementation(project(':lib:playlist-utils'))
     implementation(project(':lib:streamtape-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
 }

--- a/src/sr/animesrbija/build.gradle
+++ b/src/sr/animesrbija/build.gradle
@@ -8,5 +8,5 @@ apply from: "$rootDir/common.gradle"
 
 dependencies {
     implementation(project(':lib:filemoon-extractor'))
-    implementation("dev.datlag.jsunpacker:jsunpacker:1.0.1")
+    implementation(libs.jsunpacker)
 }

--- a/src/tr/turkanime/build.gradle
+++ b/src/tr/turkanime/build.gradle
@@ -9,7 +9,7 @@ apply from: "$rootDir/common.gradle"
 dependencies {
     implementation(project(':lib:vudeo-extractor'))
     implementation(project(':lib:uqload-extractor'))
-    implementation "dev.datlag.jsunpacker:jsunpacker:1.0.1"
+    implementation(libs.jsunpacker)
     implementation(project(":lib:cryptoaes"))
     implementation(project(":lib:dood-extractor"))
     implementation(project(':lib:filemoon-extractor'))


### PR DESCRIPTION
make all sources to share same jsunpacker from version catalog.
Skip CI so sources' version won't be bumped up, since this won't change anything.