### PR TITLE
Hanime1: Filter ads from search results and more

### DIFF
--- a/src/zh/hanime1/build.gradle
+++ b/src/zh/hanime1/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hanime1'
     extClass = '.Hanime1'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/zh/hanime1/src/eu/kanade/tachiyomi/animeextension/zh/hanime1/Hanime1.kt
+++ b/src/zh/hanime1/src/eu/kanade/tachiyomi/animeextension/zh/hanime1/Hanime1.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Cookie
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.Request
@@ -287,25 +288,50 @@ class Hanime1 : AnimeHttpSource(), ConfigurableAnimeSource {
     }
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        screen.addPreference(
-            ListPreference(screen.context).apply {
-                key = PREF_KEY_VIDEO_QUALITY
-                title = "設置首選畫質"
-                entries = arrayOf("1080P", "720P", "480P")
-                entryValues = entries
-                setDefaultValue(DEFAULT_QUALITY)
-                summary =
-                    "當前選擇：${preferences.getString(PREF_KEY_VIDEO_QUALITY, DEFAULT_QUALITY)}"
-                setOnPreferenceChangeListener { _, newValue ->
-                    summary = "當前選擇：${newValue as String}"
-                    true
-                }
-            },
-        )
+        screen.apply {
+            addPreference(
+                ListPreference(context).apply {
+                    key = PREF_KEY_VIDEO_QUALITY
+                    title = "設置首選畫質"
+                    entries = arrayOf("1080P", "720P", "480P")
+                    entryValues = entries
+                    setDefaultValue(DEFAULT_QUALITY)
+                    summary =
+                        "當前選擇：${preferences.getString(PREF_KEY_VIDEO_QUALITY, DEFAULT_QUALITY)}"
+                    setOnPreferenceChangeListener { _, newValue ->
+                        summary = "當前選擇：${newValue as String}"
+                        true
+                    }
+                },
+            )
+            addPreference(
+                ListPreference(context).apply {
+                    key = PREF_KEY_LANG
+                    title = "設置首選語言"
+                    summary = "該設置僅影響影片字幕"
+                    entries = arrayOf("繁體中文", "簡體中文")
+                    entryValues = arrayOf("zh-CHT", "zh-CHS")
+                    setOnPreferenceChangeListener { _, newValue ->
+                        val baseHttpUrl = baseUrl.toHttpUrl()
+                        client.cookieJar.saveFromResponse(
+                            baseHttpUrl,
+                            listOf(
+                                Cookie.parse(
+                                    baseHttpUrl,
+                                    "user_lang=${newValue as String}",
+                                )!!,
+                            ),
+                        )
+                        true
+                    }
+                },
+            )
+        }
     }
 
     companion object {
         const val PREF_KEY_VIDEO_QUALITY = "PREF_KEY_VIDEO_QUALITY"
+        const val PREF_KEY_LANG = "PREF_KEY_LANG"
 
         const val PREF_KEY_GENRE_LIST = "PREF_KEY_GENRE_LIST"
         const val PREF_KEY_SORT_LIST = "PREF_KEY_SORT_LIST"

--- a/src/zh/hanime1/src/eu/kanade/tachiyomi/animeextension/zh/hanime1/Hanime1.kt
+++ b/src/zh/hanime1/src/eu/kanade/tachiyomi/animeextension/zh/hanime1/Hanime1.kt
@@ -111,7 +111,7 @@ class Hanime1 : AnimeHttpSource(), ConfigurableAnimeSource {
         }.filterNot { it.videoUrl?.startsWith("blob") == true }
             .sortedByDescending { preferQuality == it.quality }
             .ifEmpty {
-                // found source from script content
+                // Try to find the source from the script content.
                 val videoUrl = doc.select("script[type=application/ld+json]").first()!!.data().let {
                     val info = json.decodeFromString<JsonElement>(it).jsonObject
                     info["contentUrl"]!!.jsonPrimitive.content

--- a/src/zh/hanime1/src/eu/kanade/tachiyomi/animeextension/zh/hanime1/Hanime1.kt
+++ b/src/zh/hanime1/src/eu/kanade/tachiyomi/animeextension/zh/hanime1/Hanime1.kt
@@ -137,7 +137,7 @@ class Hanime1 : AnimeHttpSource(), ConfigurableAnimeSource {
                 }
             }
         } else {
-            jsoup.select(".search-videos").map {
+            jsoup.select("a:not([target]) > .search-videos").map {
                 SAnime.create().apply {
                     setUrlWithoutDomain(it.parent()!!.attr("href"))
                     thumbnail_url = it.select("img").attr("src")


### PR DESCRIPTION
Some small fix:
* Filter ads from search results
* Fix the issue that some videos can't find their source
* Add a new preference to select the preferred language for subtitles


Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] Have made sure all the icons are in png format
