### PR TITLE
ci(build_push): updated Validate Gradle Wrapper

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -57,7 +57,7 @@ jobs:
       #     ./.github/scripts/bump-versions.py ${{ steps.modified-libs.outputs.all_changed_files }}
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@a494d935f4b56874c4a5a87d19af7afcf3a163d0 # v2
+        uses: gradle/actions/wrapper-validation@v4
 
       - name: Get number of modules
         run: |


### PR DESCRIPTION
Updated Validate Gradle Wrapper job from `build_push.yml` to new version.
Maybe this will solve failed runs. [example failed run](https://github.com/Kohi-den/extensions-source/actions/runs/14167793031/job/39684667322)
If not it is at least on new version.