### PR TITLE
Fix AnimePahe episode sorting and numbering logic

### DIFF
--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimePahe'
     extClass = '.AnimePahe'
-    extVersionCode = 29
+    extVersionCode = 30
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -153,7 +153,15 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
     override fun episodeListParse(response: Response): List<SEpisode> {
         val url = response.request.url.toString()
         val session = url.substringAfter("&id=").substringBefore("&")
-        return recursivePages(response, session)
+        val episodeList = recursivePages(response, session)
+
+        return episodeList
+            .sortedBy { it.date_upload } // Optional, makes sure it's in correct order
+            .mapIndexed { index, episode ->
+                episode.episode_number = (index + 1).toFloat()
+                episode.name = "Episode ${index + 1}"
+                episode
+            }
     }
 
     private fun parseEpisodePage(episodes: List<EpisodeDto>, animeSession: String): MutableList<SEpisode> {

--- a/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
+++ b/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
@@ -12,7 +12,7 @@ import org.jsoup.nodes.Element
 class HiAnime : ZoroTheme(
     "en",
     "HiAnime",
-    "https://hianime.to",
+    "https://hianime.bz",
     hosterNames = listOf(
         "HD-1",
         "HD-2",

--- a/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
+++ b/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
@@ -12,7 +12,7 @@ import org.jsoup.nodes.Element
 class HiAnime : ZoroTheme(
     "en",
     "HiAnime",
-    "https://hianime.bz",
+    "https://hianime.to",
     hosterNames = listOf(
         "HD-1",
         "HD-2",


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] Have made sure all the icons are in png format

**Problem:**  
Previously, the app directly relied on the episode numbers returned by AnimePahe's backend. This caused issues in cases where series had multiple seasons or non-standard episode numbering (e.g., a second season starting at episode 25). As a result, the app would incorrectly match new episodes (like episode 25 of season 2) with existing entries, leading to inaccurate updates and metadata.

**Fix:**  
Modified the `episodeListParse` logic to:

- Extract all episodes via the `recursivePages` function.
- Sort episodes chronologically using the `date_upload` timestamp to ensure correct order.
- Reassign episode numbers locally using the list index, so episode 1 of any series is labeled as Episode 1, regardless of its original number in AnimePahe's API.
- Generate consistent episode names like Episode 1, Episode 2, etc., improving user experience and synchronization reliability.

This ensures that episode tracking within the app is consistent and season-agnostic, preventing mismatches across multi-season series or irregular numbering schemes.







