### PR TITLE
Fix playlist-utils

### DIFF
--- a/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
+++ b/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
@@ -10,7 +10,6 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.internal.commonEmptyHeaders
 import java.io.File
-import kotlin.math.abs
 
 class PlaylistUtils(private val client: OkHttpClient, private val headers: Headers = commonEmptyHeaders) {
 
@@ -138,7 +137,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
             val resolution = it.substringAfter("RESOLUTION=")
                 .substringBefore("\n")
                 .substringAfter("x")
-                .substringBefore(",").let(::stnQuality)
+                .substringBefore(",")
 
             val videoUrl = it.substringAfter("\n").substringBefore("\n").let { url ->
                 getAbsoluteUrl(url, playlistUrl, masterUrlBasePath)?.trimEnd()
@@ -336,13 +335,6 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
     }
 
     // ============================= Utilities ==============================
-
-    private fun stnQuality(quality: String): String {
-        val intQuality = quality.trim().toInt()
-        val standardQualities = listOf(144, 240, 360, 480, 720, 1080)
-        val result =  standardQualities.minByOrNull { abs(it - intQuality) } ?: quality
-        return "${result}p"
-    }
 
     private fun cleanSubtitleData(matchResult: MatchResult): String {
         val lineCount = matchResult.groupValues[1].count { it == '\n' }

--- a/src/all/animeworldindia/build.gradle
+++ b/src/all/animeworldindia/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeWorld India'
     extClass = '.AnimeWorldIndiaFactory'
-    extVersionCode = 15
+    extVersionCode = 16
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/animexin/build.gradle
+++ b/src/all/animexin/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.AnimeXin'
     themePkg = 'animestream'
     baseUrl = 'https://animexin.vip'
-    overrideVersionCode = 10
+    overrideVersionCode = 11
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/anizone/build.gradle
+++ b/src/all/anizone/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AniZone'
     extClass = '.AniZone'
-    extVersionCode = 3
+    extVersionCode = 4
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/chineseanime/build.gradle
+++ b/src/all/chineseanime/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ChineseAnime'
     themePkg = 'animestream'
     baseUrl = 'https://www.chineseanime.vip'
-    overrideVersionCode = 14
+    overrideVersionCode = 15
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/hikari/build.gradle
+++ b/src/all/hikari/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hikari'
     extClass = '.Hikari'
-    extVersionCode = 20
+    extVersionCode = 21
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/javgg/build.gradle
+++ b/src/all/javgg/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'JavGG'
     extClass = '.Javgg'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = true
 }
 

--- a/src/all/javguru/build.gradle
+++ b/src/all/javguru/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Jav Guru'
     extClass = '.JavGuru'
-    extVersionCode = 27
+    extVersionCode = 28
     isNsfw = true
 }
 

--- a/src/all/lmanime/build.gradle
+++ b/src/all/lmanime/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.LMAnime'
     themePkg = 'animestream'
     baseUrl = 'https://lmanime.com'
-    overrideVersionCode = 10
+    overrideVersionCode = 11
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/missav/build.gradle
+++ b/src/all/missav/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MissAV'
     extClass = '.MissAV'
-    extVersionCode = 15
+    extVersionCode = 16
     isNsfw = true
 }
 

--- a/src/all/sudatchi/build.gradle
+++ b/src/all/sudatchi/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Sudatchi'
     extClass = '.Sudatchi'
-    extVersionCode = 12
+    extVersionCode = 13
     isNsfw = true
 }
 

--- a/src/all/supjav/build.gradle
+++ b/src/all/supjav/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'SupJav'
     extClass = '.SupJavFactory'
-    extVersionCode = 15
+    extVersionCode = 16
     isNsfw = true
 }
 

--- a/src/ar/anime4up/build.gradle
+++ b/src/ar/anime4up/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anime4up'
     extClass = '.Anime4Up'
-    extVersionCode = 63
+    extVersionCode = 64
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/animeblkom/build.gradle
+++ b/src/ar/animeblkom/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anime Blkom'
     extClass = '.AnimeBlkom'
-    extVersionCode = 18
+    extVersionCode = 19
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/animelek/build.gradle
+++ b/src/ar/animelek/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeLek'
     extClass = '.AnimeLek'
-    extVersionCode = 31
+    extVersionCode = 32
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/animerco/build.gradle
+++ b/src/ar/animerco/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animerco'
     extClass = '.Animerco'
-    extVersionCode = 42
+    extVersionCode = 43
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/arabseed/build.gradle
+++ b/src/ar/arabseed/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Arab Seed'
     extClass = '.ArabSeed'
-    extVersionCode = 18
+    extVersionCode = 19
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/asia2tv/build.gradle
+++ b/src/ar/asia2tv/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'asia2tv'
     extClass = '.Asia2TV'
-    extVersionCode = 23
+    extVersionCode = 24
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/cimaleek/build.gradle
+++ b/src/ar/cimaleek/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Cimaleek'
     extClass = '.Cimaleek'
-    extVersionCode = 3
+    extVersionCode = 4
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/egydead/build.gradle
+++ b/src/ar/egydead/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Egy Dead'
     extClass = '.EgyDead'
-    extVersionCode = 18
+    extVersionCode = 19
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/faselhd/build.gradle
+++ b/src/ar/faselhd/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'FASELHD'
     extClass = '.FASELHD'
-    extVersionCode = 17
+    extVersionCode = 18
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/mycima/build.gradle
+++ b/src/ar/mycima/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MY CIMA'
     extClass = '.MyCima'
-    extVersionCode = 23
+    extVersionCode = 24
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/okanime/build.gradle
+++ b/src/ar/okanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Okanime'
     extClass = '.Okanime'
-    extVersionCode = 13
+    extVersionCode = 14
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/witanime/build.gradle
+++ b/src/ar/witanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'WIT ANIME'
     extClass = '.WitAnime'
-    extVersionCode = 51
+    extVersionCode = 52
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/de/animebase/build.gradle
+++ b/src/de/animebase/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anime-Base'
     extClass = '.AnimeBase'
-    extVersionCode = 32
+    extVersionCode = 33
     isNsfw = true
 }
 

--- a/src/de/animeloads/build.gradle
+++ b/src/de/animeloads/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anime-Loads'
     extClass = '.AnimeLoads'
-    extVersionCode = 17
+    extVersionCode = 18
     isNsfw = true
 }
 

--- a/src/de/animetoast/build.gradle
+++ b/src/de/animetoast/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeToast'
     extClass = '.AnimeToast'
-    extVersionCode = 22
+    extVersionCode = 23
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/de/aniworld/build.gradle
+++ b/src/de/aniworld/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AniWorld'
     extClass = '.AniWorld'
-    extVersionCode = 25
+    extVersionCode = 26
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/de/cinemathek/build.gradle
+++ b/src/de/cinemathek/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Cinemathek'
     themePkg = 'dooplay'
     baseUrl = 'https://cinemathek.net'
-    overrideVersionCode = 25
+    overrideVersionCode = 26
     isNsfw = true
 }
 

--- a/src/de/einfach/build.gradle
+++ b/src/de/einfach/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Einfach'
     extClass = '.Einfach'
-    extVersionCode = 17
+    extVersionCode = 18
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/de/filmpalast/build.gradle
+++ b/src/de/filmpalast/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'FilmPalast'
     extClass = '.FilmPalast'
-    extVersionCode = 19
+    extVersionCode = 20
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/de/kinoking/build.gradle
+++ b/src/de/kinoking/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Kinoking'
     themePkg = 'dooplay'
     baseUrl = 'https://kinoking.cc'
-    overrideVersionCode = 23
+    overrideVersionCode = 24
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/de/kool/build.gradle
+++ b/src/de/kool/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Kool'
     extClass = '.Kool'
-    extVersionCode = 14
+    extVersionCode = 15
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/de/moflixstream/build.gradle
+++ b/src/de/moflixstream/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Moflix-Stream'
     extClass = '.MoflixStream'
-    extVersionCode = 16
+    extVersionCode = 17
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/de/movie4k/build.gradle
+++ b/src/de/movie4k/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Movie4k'
     extClass = '.Movie4k'
-    extVersionCode = 11
+    extVersionCode = 12
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/de/serienstream/build.gradle
+++ b/src/de/serienstream/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Serienstream'
     extClass = '.Serienstream'
-    extVersionCode = 24
+    extVersionCode = 25
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/allanime/build.gradle
+++ b/src/en/allanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AllAnime'
     extClass = '.AllAnime'
-    extVersionCode = 36
+    extVersionCode = 37
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/allanimechi/build.gradle
+++ b/src/en/allanimechi/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AllAnimeChi'
     extClass = '.AllAnimeChi'
-    extVersionCode = 13
+    extVersionCode = 14
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/animekhor/build.gradle
+++ b/src/en/animekhor/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.AnimeKhor'
     themePkg = 'animestream'
     baseUrl = 'https://animekhor.org'
-    overrideVersionCode = 8
+    overrideVersionCode = 9
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/animenosub/build.gradle
+++ b/src/en/animenosub/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Animenosub'
     themePkg = 'animestream'
     baseUrl = 'https://animenosub.com'
-    overrideVersionCode = 9
+    overrideVersionCode = 10
     isNsfw = true
 }
 

--- a/src/en/animeowl/build.gradle
+++ b/src/en/animeowl/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeOwl'
     extClass = '.AnimeOwl'
-    extVersionCode = 23
+    extVersionCode = 24
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/animetake/build.gradle
+++ b/src/en/animetake/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeTake'
     extClass = '.AnimeTake'
-    extVersionCode = 8
+    extVersionCode = 9
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/aniplay/build.gradle
+++ b/src/en/aniplay/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'AniPlay'
     extClass = '.AniPlay'
     themePkg = 'anilist'
-    overrideVersionCode = 18
+    overrideVersionCode = 19
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/asiaflix/build.gradle
+++ b/src/en/asiaflix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AsiaFlix'
     extClass = '.AsiaFlix'
-    extVersionCode = 17
+    extVersionCode = 18
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/donghuastream/build.gradle
+++ b/src/en/donghuastream/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.DonghuaStream'
     themePkg = 'animestream'
     baseUrl = 'https://donghuastream.org'
-    overrideVersionCode = 9
+    overrideVersionCode = 10
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/dopebox/build.gradle
+++ b/src/en/dopebox/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.DopeBox'
     themePkg = 'dopeflix'
     baseUrl = 'https://dopebox.to'
-    overrideVersionCode = 11
+    overrideVersionCode = 12
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/kaido/build.gradle
+++ b/src/en/kaido/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Kaido'
     themePkg = 'zorotheme'
     baseUrl = 'https://kaido.to'
-    overrideVersionCode = 8
+    overrideVersionCode = 9
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/kickassanime/build.gradle
+++ b/src/en/kickassanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'KickAssAnime'
     extClass = '.KickAssAnime'
-    extVersionCode = 47
+    extVersionCode = 48
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/kissanime/build.gradle
+++ b/src/en/kissanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'KissAnime'
     extClass = '.KissAnime'
-    extVersionCode = 7
+    extVersionCode = 8
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/luciferdonghua/build.gradle
+++ b/src/en/luciferdonghua/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.LuciferDonghua'
     themePkg = 'animestream'
     baseUrl = 'https://luciferdonghua.in'
-    overrideVersionCode = 7
+    overrideVersionCode = 8
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/myanime/build.gradle
+++ b/src/en/myanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Myanime'
     extClass = '.Myanime'
-    extVersionCode = 6
+    extVersionCode = 7
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/putlocker/build.gradle
+++ b/src/en/putlocker/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'PutLocker'
     extClass = '.PutLocker'
-    extVersionCode = 10
+    extVersionCode = 11
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/sflix/build.gradle
+++ b/src/en/sflix/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.SFlix'
     themePkg = 'dopeflix'
     baseUrl = 'https://sflix.to'
-    overrideVersionCode = 10
+    overrideVersionCode = 11
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/tokuzilla/build.gradle
+++ b/src/en/tokuzilla/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Tokuzilla'
     extClass = '.Tokuzilla'
-    extVersionCode = 23
+    extVersionCode = 24
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/zoro/build.gradle
+++ b/src/en/zoro/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.HiAnime'
     themePkg = 'zorotheme'
     baseUrl = 'https://hianimez.to'
-    overrideVersionCode = 50
+    overrideVersionCode = 51
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/animebum/build.gradle
+++ b/src/es/animebum/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeBum'
     extClass = '.AnimeBum'
-    extVersionCode = 6
+    extVersionCode = 7
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/animefenix/build.gradle
+++ b/src/es/animefenix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animefenix'
     extClass = '.Animefenix'
-    extVersionCode = 58
+    extVersionCode = 59
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/animeflv/build.gradle
+++ b/src/es/animeflv/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeFLV'
     extClass = '.AnimeFlv'
-    extVersionCode = 65
+    extVersionCode = 66
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/animeid/build.gradle
+++ b/src/es/animeid/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeID'
     extClass = '.AnimeID'
-    extVersionCode = 17
+    extVersionCode = 18
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/animejl/build.gradle
+++ b/src/es/animejl/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animejl'
     extClass = '.Animejl'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = true
 }
 

--- a/src/es/animelatinohd/build.gradle
+++ b/src/es/animelatinohd/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeLatinoHD'
     extClass = '.AnimeLatinoHD'
-    extVersionCode = 40
+    extVersionCode = 41
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/animemovil/build.gradle
+++ b/src/es/animemovil/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeMovil'
     extClass = '.AnimeMovil'
-    extVersionCode = 30
+    extVersionCode = 31
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/animenix/build.gradle
+++ b/src/es/animenix/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Animenix'
     themePkg = 'dooplay'
     baseUrl = 'https://animenix.com'
-    overrideVersionCode = 10
+    overrideVersionCode = 11
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/animeonlineninja/build.gradle
+++ b/src/es/animeonlineninja/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.AnimeOnlineNinja'
     themePkg = 'dooplay'
     baseUrl = 'https://ww3.animeonline.ninja'
-    overrideVersionCode = 45
+    overrideVersionCode = 46
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/animeyt/build.gradle
+++ b/src/es/animeyt/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animeyt'
     extClass = '.Animeyt'
-    extVersionCode = 11
+    extVersionCode = 12
 }
 apply from: "$rootDir/common.gradle"
 

--- a/src/es/animeytes/build.gradle
+++ b/src/es/animeytes/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.AnimeYTES'
     themePkg = 'animestream'
     baseUrl = 'https://animeyt.pro'
-    overrideVersionCode = 10
+    overrideVersionCode = 11
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/asialiveaction/build.gradle
+++ b/src/es/asialiveaction/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AsiaLiveAction'
     extClass = '.AsiaLiveAction'
-    extVersionCode = 37
+    extVersionCode = 38
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/cine24h/build.gradle
+++ b/src/es/cine24h/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Cine24h'
     extClass = '.Cine24h'
-    extVersionCode = 12
+    extVersionCode = 13
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/cinecalidad/build.gradle
+++ b/src/es/cinecalidad/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'CineCalidad'
     extClass = '.CineCalidad'
-    extVersionCode = 18
+    extVersionCode = 19
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/cineplus123/build.gradle
+++ b/src/es/cineplus123/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Cineplus123'
     themePkg = 'dooplay'
     baseUrl = 'https://cineplus123.org'
-    overrideVersionCode = 7
+    overrideVersionCode = 8
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/cuevana/build.gradle
+++ b/src/es/cuevana/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Cuevana'
     extClass = '.CuevanaFactory'
-    extVersionCode = 47
+    extVersionCode = 48
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/detodopeliculas/build.gradle
+++ b/src/es/detodopeliculas/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.DeTodoPeliculas'
     themePkg = 'dooplay'
     baseUrl = 'https://detodopeliculas.nu'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/doramasflix/build.gradle
+++ b/src/es/doramasflix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Doramasflix'
     extClass = '.Doramasflix'
-    extVersionCode = 34
+    extVersionCode = 35
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/doramasyt/build.gradle
+++ b/src/es/doramasyt/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Doramasyt'
     extClass = '.Doramasyt'
-    extVersionCode = 21
+    extVersionCode = 22
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/ennovelas/build.gradle
+++ b/src/es/ennovelas/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'EnNovelas'
     extClass = '.EnNovelas'
-    extVersionCode = 20
+    extVersionCode = 21
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/estrenosdoramas/build.gradle
+++ b/src/es/estrenosdoramas/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'EstrenosDoramas'
     extClass = '.EstrenosDoramas'
-    extVersionCode = 6
+    extVersionCode = 7
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/fanpelis/build.gradle
+++ b/src/es/fanpelis/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'FanPelis'
     extClass = '.FanPelis'
-    extVersionCode = 16
+    extVersionCode = 17
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/flixlatam/build.gradle
+++ b/src/es/flixlatam/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.FlixLatam'
     themePkg = 'dooplay'
     baseUrl = 'https://flixlatam.com'
-    overrideVersionCode = 5
+    overrideVersionCode = 6
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/gnula/build.gradle
+++ b/src/es/gnula/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Gnula'
     extClass = '.Gnula'
-    extVersionCode = 32
+    extVersionCode = 33
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/hackstore/build.gradle
+++ b/src/es/hackstore/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hackstore'
     extClass = '.Hackstore'
-    extVersionCode = 26
+    extVersionCode = 27
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/hentaijk/build.gradle
+++ b/src/es/hentaijk/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hentaijk'
     extClass = '.Hentaijk'
-    extVersionCode = 12
+    extVersionCode = 13
     isNsfw = true
 }
 

--- a/src/es/hentaila/build.gradle
+++ b/src/es/hentaila/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'HentaiLA'
     extClass = '.Hentaila'
-    extVersionCode = 35
+    extVersionCode = 36
     isNsfw = true
 }
 

--- a/src/es/hentaitk/build.gradle
+++ b/src/es/hentaitk/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'HentaiTk'
     extClass = '.Hentaitk'
-    extVersionCode = 14
+    extVersionCode = 15
     isNsfw = true
 }
 

--- a/src/es/homecine/build.gradle
+++ b/src/es/homecine/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'HomeCine'
     extClass = '.HomeCine'
-    extVersionCode = 6
+    extVersionCode = 7
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/jkanime/build.gradle
+++ b/src/es/jkanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Jkanime'
     extClass = '.Jkanime'
-    extVersionCode = 36
+    extVersionCode = 37
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/katanime/build.gradle
+++ b/src/es/katanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Katanime'
     extClass = '.Katanime'
-    extVersionCode = 6
+    extVersionCode = 7
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/lacartoons/build.gradle
+++ b/src/es/lacartoons/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'LACartoons'
     extClass = '.Lacartoons'
-    extVersionCode = 12
+    extVersionCode = 13
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/latanime/build.gradle
+++ b/src/es/latanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Latanime'
     extClass = '.Latanime'
-    extVersionCode = 24
+    extVersionCode = 25
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/legionanime/build.gradle
+++ b/src/es/legionanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'LegionAnime'
     extClass = '.LegionAnime'
-    extVersionCode = 36
+    extVersionCode = 37
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/locopelis/build.gradle
+++ b/src/es/locopelis/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'LocoPelis'
     extClass = '.LocoPelis'
-    extVersionCode = 29
+    extVersionCode = 30
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/metroseries/build.gradle
+++ b/src/es/metroseries/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MetroSeries'
     extClass = '.MetroSeries'
-    extVersionCode = 19
+    extVersionCode = 20
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/mhdflix/build.gradle
+++ b/src/es/mhdflix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MhdFlix'
     extClass = '.MhdFlix'
-    extVersionCode = 7
+    extVersionCode = 8
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/monoschinos/build.gradle
+++ b/src/es/monoschinos/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MonosChinos'
     extClass = '.MonosChinos'
-    extVersionCode = 36
+    extVersionCode = 37
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/mundodonghua/build.gradle
+++ b/src/es/mundodonghua/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MundoDonghua'
     extClass = '.MundoDonghua'
-    extVersionCode = 30
+    extVersionCode = 31
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/otakuverso/build.gradle
+++ b/src/es/otakuverso/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Otakuverso'
     extClass = '.Otakuverso'
-    extVersionCode = 2
+    extVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/pandrama/build.gradle
+++ b/src/es/pandrama/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Pandrama'
     extClass = '.Pandrama'
-    extVersionCode = 2
+    extVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/pelisforte/build.gradle
+++ b/src/es/pelisforte/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'PelisForte'
     extClass = '.PelisForte'
-    extVersionCode = 31
+    extVersionCode = 32
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/pelisplushd/build.gradle
+++ b/src/es/pelisplushd/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Pelisplushd'
     extClass = '.PelisplushdFactory'
-    extVersionCode = 74
+    extVersionCode = 75
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/serieskao/build.gradle
+++ b/src/es/serieskao/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Serieskao'
     extClass = '.Serieskao'
-    extVersionCode = 5
+    extVersionCode = 6
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/sololatino/build.gradle
+++ b/src/es/sololatino/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.SoloLatino'
     themePkg = 'dooplay'
     baseUrl = 'https://sololatino.net'
-    overrideVersionCode = 7
+    overrideVersionCode = 8
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/tioanimeh/build.gradle
+++ b/src/es/tioanimeh/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'TioanimeH'
     extClass = '.TioanimeHFactory'
-    extVersionCode = 25
+    extVersionCode = 26
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/tiodonghua/build.gradle
+++ b/src/es/tiodonghua/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Tiodonghua'
     themePkg = 'animestream'
     baseUrl = 'https://anime.tiodonghua.com'
-    overrideVersionCode = 6
+    overrideVersionCode = 7
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/veranimes/build.gradle
+++ b/src/es/veranimes/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'VerAnimes'
     extClass = '.VerAnimes'
-    extVersionCode = 11
+    extVersionCode = 12
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/verseriesonline/build.gradle
+++ b/src/es/verseriesonline/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'VerSeriesOnline'
     extClass = '.VerSeriesOnline'
-    extVersionCode = 5
+    extVersionCode = 6
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/zeroanime/build.gradle
+++ b/src/es/zeroanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'zeroanime'
     extClass = '.Zeroanime'
-    extVersionCode = 4
+    extVersionCode = 5
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/zonaleros/build.gradle
+++ b/src/es/zonaleros/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Zonaleros'
     extClass = '.Zonaleros'
-    extVersionCode = 2
+    extVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/animesama/build.gradle
+++ b/src/fr/animesama/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anime-Sama'
     extClass = '.AnimeSama'
-    extVersionCode = 11
+    extVersionCode = 12
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/anisama/build.gradle
+++ b/src/fr/anisama/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AniSama'
     extClass = '.AniSama'
-    extVersionCode = 12
+    extVersionCode = 13
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/empirestreaming/build.gradle
+++ b/src/fr/empirestreaming/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'EmpireStreaming'
     extClass = '.EmpireStreaming'
-    extVersionCode = 18
+    extVersionCode = 19
 }
 apply from: "$rootDir/common.gradle"
 

--- a/src/fr/franime/build.gradle
+++ b/src/fr/franime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'FrAnime'
     extClass = '.FrAnime'
-    extVersionCode = 17
+    extVersionCode = 18
     isNsfw = true
 }
 apply from: "$rootDir/common.gradle"

--- a/src/fr/frenchanime/build.gradle
+++ b/src/fr/frenchanime/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.FrenchAnime'
     themePkg = 'datalifeengine'
     baseUrl = 'https://french-anime.com'
-    overrideVersionCode = 17
+    overrideVersionCode = 18
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/hds/build.gradle
+++ b/src/fr/hds/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Hds'
     themePkg = 'dooplay'
     baseUrl = 'https://www.hds.quest'
-    overrideVersionCode = 5
+    overrideVersionCode = 6
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/jetanime/build.gradle
+++ b/src/fr/jetanime/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.JetAnime'
     themePkg = 'dooplay'
     baseUrl = 'https://ssl.jetanimes.com'
-    overrideVersionCode = 9
+    overrideVersionCode = 10
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/mykdrama/build.gradle
+++ b/src/fr/mykdrama/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MyKdrama'
     themePkg = 'animestream'
     baseUrl = 'https://mykdrama.co'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/otakufr/build.gradle
+++ b/src/fr/otakufr/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'OtakuFR'
     extClass = '.OtakuFR'
-    extVersionCode = 26
+    extVersionCode = 27
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/voircartoon/build.gradle
+++ b/src/fr/voircartoon/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.VoirCartoon'
     themePkg = 'dooplay'
     baseUrl = 'https://voircartoon.com'
-    overrideVersionCode = 7
+    overrideVersionCode = 8
     isNsfw = true
 }
 

--- a/src/fr/vostfree/build.gradle
+++ b/src/fr/vostfree/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Vostfree'
     extClass = '.Vostfree'
-    extVersionCode = 26
+    extVersionCode = 27
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/wiflix/build.gradle
+++ b/src/fr/wiflix/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Wiflix'
     themePkg = 'datalifeengine'
     baseUrl = 'https://wiflix.voto'
-    overrideVersionCode = 15
+    overrideVersionCode = 16
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/hi/animesaga/build.gradle
+++ b/src/hi/animesaga/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.AniSAGA'
     themePkg = 'dooplay'
     baseUrl = 'https://www.anisaga.org'
-    overrideVersionCode = 19
+    overrideVersionCode = 20
     isNsfw = false
 }
 

--- a/src/hi/yomovies/build.gradle
+++ b/src/hi/yomovies/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'YoMovies'
     extClass = '.YoMovies'
-    extVersionCode = 23
+    extVersionCode = 24
     isNsfw = true
 }
 

--- a/src/id/animeindo/build.gradle
+++ b/src/id/animeindo/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.AnimeIndo'
     themePkg = 'animestream'
     baseUrl = 'https://animeindo.skin'
-    overrideVersionCode = 12
+    overrideVersionCode = 13
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/neonime/build.gradle
+++ b/src/id/neonime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'NeoNime'
     extClass = '.NeoNime'
-    extVersionCode = 14
+    extVersionCode = 15
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/otakudesu/build.gradle
+++ b/src/id/otakudesu/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'OtakuDesu'
     extClass = '.OtakuDesu'
-    extVersionCode = 32
+    extVersionCode = 33
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/it/animeworld/build.gradle
+++ b/src/it/animeworld/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ANIMEWORLD.tv'
     extClass = '.ANIMEWORLD'
-    extVersionCode = 47
+    extVersionCode = 48
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/it/aniplay/build.gradle
+++ b/src/it/aniplay/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AniPlay'
     extClass = '.AniPlay'
-    extVersionCode = 13
+    extVersionCode = 14
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/it/toonitalia/build.gradle
+++ b/src/it/toonitalia/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Toonitalia'
     extClass = '.Toonitalia'
-    extVersionCode = 25
+    extVersionCode = 26
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ko/aniweek/build.gradle
+++ b/src/ko/aniweek/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Aniweek'
     extClass = '.Aniweek'
-    extVersionCode = 10
+    extVersionCode = 11
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pl/desuonline/build.gradle
+++ b/src/pl/desuonline/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.DesuOnline'
     themePkg = 'animestream'
     baseUrl = 'https://desu-online.pl'
-    overrideVersionCode = 5
+    overrideVersionCode = 6
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pl/docchi/build.gradle
+++ b/src/pl/docchi/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Docchi'
     extClass = '.Docchi'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/pl/wbijam/build.gradle
+++ b/src/pl/wbijam/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Wbijam'
     extClass = '.Wbijam'
-    extVersionCode = 5
+    extVersionCode = 6
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/animesbr/build.gradle
+++ b/src/pt/animesbr/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.AnimesBr'
     themePkg = 'dooplay'
     baseUrl = 'https://animesbr.tv'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/pt/animesgratis/build.gradle
+++ b/src/pt/animesgratis/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Q1N'
     themePkg = 'dooplay'
     baseUrl = 'https://q1n.net'
-    overrideVersionCode = 19
+    overrideVersionCode = 20
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/darkmahou/build.gradle
+++ b/src/pt/darkmahou/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.DarkMahou'
     themePkg = 'animestream'
     baseUrl = 'https://darkmahou.org'
-    overrideVersionCode = 3
+    overrideVersionCode = 4
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/doramogo/build.gradle
+++ b/src/pt/doramogo/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Doramogo'
     extClass = '.Doramogo'
-    extVersionCode = 6
+    extVersionCode = 7
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/pifansubs/build.gradle
+++ b/src/pt/pifansubs/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.PiFansubs'
     themePkg = 'dooplay'
     baseUrl = 'https://pifansubs.club'
-    overrideVersionCode = 22
+    overrideVersionCode = 23
     isNsfw = true
 }
 

--- a/src/ru/animelib/build.gradle
+++ b/src/ru/animelib/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animelib'
     extClass = '.Animelib'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/sr/animebalkan/build.gradle
+++ b/src/sr/animebalkan/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.AnimeBalkan'
     themePkg = 'animestream'
     baseUrl = 'https://animebalkan.org'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/sr/animesrbija/build.gradle
+++ b/src/sr/animesrbija/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anime Srbija'
     extClass = '.AnimeSrbija'
-    extVersionCode = 12
+    extVersionCode = 13
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/tr/animeler/build.gradle
+++ b/src/tr/animeler/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animeler'
     extClass = '.Animeler'
-    extVersionCode = 17
+    extVersionCode = 18
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/tr/anizm/build.gradle
+++ b/src/tr/anizm/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anizm'
     extClass = '.Anizm'
-    extVersionCode = 26
+    extVersionCode = 27
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/tr/asyaanimeleri/build.gradle
+++ b/src/tr/asyaanimeleri/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.AsyaAnimeleri'
     themePkg = 'animestream'
     baseUrl = 'https://asyaanimeleri.com'
-    overrideVersionCode = 5
+    overrideVersionCode = 6
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/tr/hdfilmcehennemi/build.gradle
+++ b/src/tr/hdfilmcehennemi/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'HDFilmCehennemi'
     extClass = '.HDFilmCehennemi'
-    extVersionCode = 21
+    extVersionCode = 22
     isNsfw = true
 }
 

--- a/src/tr/tranimeizle/build.gradle
+++ b/src/tr/tranimeizle/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'TR Anime Izle'
     extClass = '.TRAnimeIzle'
-    extVersionCode = 22
+    extVersionCode = 23
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/tr/turkanime/build.gradle
+++ b/src/tr/turkanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Türk Anime TV'
     extClass = '.TurkAnime'
-    extVersionCode = 35
+    extVersionCode = 36
 }
 
 apply from: "$rootDir/common.gradle"


### PR DESCRIPTION
Playlist utils would "standardize" all qualities for every ext using playlist-utils which is a bad idea. Instead its done only on the extractor that introduced it

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [x] Have made sure all the icons are in png format
