### PR TITLE
feat(es:lacartoons): Add Sendvid extractor support

### DIFF
--- a/src/es/lacartoons/build.gradle
+++ b/src/es/lacartoons/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'LACartoons'
     extClass = '.Lacartoons'
-    extVersionCode = 18
+    extVersionCode = 19
 }
 
 apply from: "$rootDir/common.gradle"
@@ -13,4 +13,5 @@ dependencies {
     implementation(project(':lib:voe-extractor'))
     implementation(project(':lib:yourupload-extractor'))
     implementation(project(':lib:universal-extractor'))
+    implementation(project(':lib:sendvid-extractor'))
 }

--- a/src/es/lacartoons/src/eu/kanade/tachiyomi/animeextension/es/lacartoons/Lacartoons.kt
+++ b/src/es/lacartoons/src/eu/kanade/tachiyomi/animeextension/es/lacartoons/Lacartoons.kt
@@ -13,6 +13,7 @@ import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.lib.okruextractor.OkruExtractor
+import eu.kanade.tachiyomi.lib.sendvidextractor.SendvidExtractor
 import eu.kanade.tachiyomi.lib.streamhidevidextractor.StreamHideVidExtractor
 import eu.kanade.tachiyomi.lib.streamwishextractor.StreamWishExtractor
 import eu.kanade.tachiyomi.lib.universalextractor.UniversalExtractor
@@ -54,6 +55,7 @@ class Lacartoons : ConfigurableAnimeSource, AnimeHttpSource() {
             "YourUpload",
             "FileLions",
             "StreamHideVid",
+            "Sendvid",
         )
     }
 
@@ -134,6 +136,7 @@ class Lacartoons : ConfigurableAnimeSource, AnimeHttpSource() {
 
     private fun serverVideoResolver(url: String): List<Video> {
         val embedUrl = url.lowercase()
+        val extractor = SendvidExtractor(client, headers)
         return when {
             embedUrl.contains("ok.ru") || embedUrl.contains("okru") -> OkruExtractor(client).videosFromUrl(url)
             embedUrl.contains("filelions") || embedUrl.contains("lion") -> StreamWishExtractor(client, headers).videosFromUrl(url, videoNameGen = { "FileLions:$it" })
@@ -148,6 +151,7 @@ class Lacartoons : ConfigurableAnimeSource, AnimeHttpSource() {
                 embedUrl.contains("guccihide") || embedUrl.contains("streamvid") -> StreamHideVidExtractor(client, headers).videosFromUrl(url)
             embedUrl.contains("voe") -> VoeExtractor(client, headers).videosFromUrl(url)
             embedUrl.contains("yourupload") || embedUrl.contains("upload") -> YourUploadExtractor(client).videoFromUrl(url, headers = headers)
+            embedUrl.contains("sendvid") -> extractor.videosFromUrl(url)
             else -> UniversalExtractor(client).videosFromUrl(url, headers)
         }
     }


### PR DESCRIPTION
## Purpose
This PR adds support for the Sendvid provider in the LACartoons extension. 

## Technical Changes
- Updated `Lacartoons.kt` to include "Sendvid" in the `SERVER_LIST`.
- Modified `serverVideoResolver` to route Sendvid URLs through the `SendvidExtractor`.
- Utilized the shared `SendvidExtractor` which supports HLS (m3u8) streams via `PlaylistUtils`.

## Testing
- **Series tested:** "La Robot Adolescente" (which currently relies heavily on Sendvid).
- **Device:** Poco X7 Pro.
- Verified that available quality is correctly parsed and playable.

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format
