### PR TITLE
de/aniworld: Use hidden search endpoint for faster fetching

### DIFF
--- a/src/de/aniworld/build.gradle
+++ b/src/de/aniworld/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AniWorld'
     extClass = '.AniWorld'
-    extVersionCode = 30
+    extVersionCode = 31
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/de/aniworld/src/eu/kanade/tachiyomi/animeextension/de/aniworld/AniWorld.kt
+++ b/src/de/aniworld/src/eu/kanade/tachiyomi/animeextension/de/aniworld/AniWorld.kt
@@ -17,14 +17,11 @@ import eu.kanade.tachiyomi.lib.doodextractor.DoodExtractor
 import eu.kanade.tachiyomi.lib.streamtapeextractor.StreamTapeExtractor
 import eu.kanade.tachiyomi.lib.voeextractor.VoeExtractor
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import okhttp3.FormBody
 import okhttp3.Headers
 import okhttp3.Request
 import okhttp3.Response
@@ -33,6 +30,7 @@ import org.jsoup.nodes.Element
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
+import java.net.URLEncoder
 
 class AniWorld : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
@@ -94,18 +92,16 @@ class AniWorld : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request {
         val headers = Headers.Builder()
-            .add("Referer", "https://aniworld.to/search")
+            .add("Referer", "$baseUrl/search")
             .add("origin", baseUrl)
             .add("connection", "keep-alive")
             .add("user-agent", "Mozilla/5.0 (Linux; Android 12; Pixel 5 Build/SP2A.220405.004; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/100.0.4896.127 Safari/537.36")
             .add("Upgrade-Insecure-Requests", "1")
-            .add("content-length", query.length.plus(8).toString())
             .add("cache-control", "")
             .add("accept", "*/*")
-            .add("content-type", "application/x-www-form-urlencoded; charset=UTF-8")
             .add("x-requested-with", "XMLHttpRequest")
             .build()
-        return POST("$baseUrl/ajax/search", body = FormBody.Builder().add("keyword", query).build(), headers = headers)
+        return GET("$baseUrl/ajax/seriesSearch?keyword=${URLEncoder.encode(query, "UTF-8")}", headers = headers)
     }
     override fun searchAnimeSelector() = throw UnsupportedOperationException()
 
@@ -114,26 +110,22 @@ class AniWorld : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     override fun searchAnimeParse(response: Response): AnimesPage {
         val body = response.body.string()
         val results = json.decodeFromString<JsonArray>(body)
-        val animes = results.filter {
-            val link = it.jsonObject["link"]!!.jsonPrimitive.content
-            link.startsWith("/anime/stream/") &&
-                link.count { c -> c == '/' } == 3
-        }.map {
-            animeFromSearch(it.jsonObject)
+        val animes = results.mapNotNull {
+            val obj = it.jsonObject
+            val name = obj["name"]?.jsonPrimitive?.content ?: return@mapNotNull null
+            val link = obj["link"]?.jsonPrimitive?.content ?: return@mapNotNull null
+
+            SAnime.create().apply {
+                title = name
+                url = "/anime/stream/$link"
+                thumbnail_url = obj["cover"]?.jsonPrimitive?.content?.replace("150x225", "220x330")?.let {
+                        cover ->
+                    "$baseUrl$cover"
+                }
+                description = obj["description"]?.jsonPrimitive?.content
+            }
         }
         return AnimesPage(animes, false)
-    }
-
-    private fun animeFromSearch(result: JsonObject): SAnime {
-        val anime = SAnime.create()
-        val title = result["title"]!!.jsonPrimitive.content
-        val link = result["link"]!!.jsonPrimitive.content
-        anime.title = title.replace("<em>", "").replace("</em>", "")
-        val thumpage = client.newCall(GET("$baseUrl$link")).execute().asJsoup()
-        anime.thumbnail_url = baseUrl +
-            thumpage.selectFirst("div.seriesCoverBox img")!!.attr("data-src")
-        anime.url = link
-        return anime
     }
 
     override fun searchAnimeFromElement(element: Element) = throw UnsupportedOperationException()


### PR DESCRIPTION
Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [X] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [X] Have removed `web_hi_res_512.png` when adding a new extension
- [X] Have made sure all the icons are in png format

---

Replaces the `/ajax/search` endpoint with the hidden `/ajax/seriesSearch` which also returns thumbnails URLs. This thumbnail is low quality and gets modified to the highest quality one with a replacement in the URL.