### PR TITLE
fix(en/animepahe): update domain and skip failed video sources

### DIFF
--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimePahe'
     extClass = '.AnimePahe'
-    extVersionCode = 33
+    extVersionCode = 34
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -204,11 +204,15 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
     override fun videoListParse(response: Response): List<Video> {
         val document = response.asJsoup()
         val downloadLinks = document.select("div#pickDownload > a")
-        return document.select("div#resolutionMenu > button").mapIndexed { index, btn ->
+        return document.select("div#resolutionMenu > button").mapIndexedNotNull { index, btn ->
             val kwikLink = btn.attr("data-src")
             val quality = btn.text()
             val paheWinLink = downloadLinks[index].attr("href")
-            getVideo(paheWinLink, kwikLink, quality)
+            try {
+                getVideo(paheWinLink, kwikLink, quality)
+            } catch (e: Exception) {
+                null
+            }
         }
     }
 
@@ -353,8 +357,8 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
 
         private const val PREF_DOMAIN_KEY = "preffered_domain"
         private const val PREF_DOMAIN_TITLE = "Preferred domain (requires app restart)"
-        private const val PREF_DOMAIN_DEFAULT = "https://animepahe.si"
-        private val PREF_DOMAIN_ENTRIES = arrayOf("animepahe.si", "animepahe.com", "animepahe.org")
+        private const val PREF_DOMAIN_DEFAULT = "https://animepahe.pw"
+        private val PREF_DOMAIN_ENTRIES = arrayOf("animepahe.pw", "animepahe.com", "animepahe.org")
         private val PREF_DOMAIN_VALUES by lazy {
             PREF_DOMAIN_ENTRIES.map { "https://" + it }.toTypedArray()
         }


### PR DESCRIPTION
- Replaced default domain from `.si` to `.pw`
- Prevented the entire source list from failing when individual getVideo calls throw exceptions. (Fixed kobayashi video loading error)
- Fix anime null status error