### PR TITLE
(en/animepahe) Fix HLS loading failed 

### DIFF
--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 ext {
     extName = 'AnimePahe'
     extClass = '.AnimePahe'
-    extVersionCode = 36
+    extVersionCode = 37
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -193,7 +193,7 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
                     videoUrl = kwikLink,
                     videoTitle = qualityStr,
                     resolution = quality,
-                    headers = Headers.headersOf("referer", "https://kwik.cx"),
+                    headers = Headers.headersOf("referer", "https://kwik.cx/"),
                     preferred = isPreferred,
                 )
             } else {
@@ -267,10 +267,10 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
         try {
             val (resolvedUrl, headers) = if (useHLS) {
                 val hlsUrl = extractor.getHlsStreamUrl(video.videoUrl, referer = baseUrl)
-                hlsUrl to Headers.headersOf("referer", "https://kwik.cx")
+                hlsUrl to Headers.headersOf("referer", "https://kwik.cx/")
             } else {
                 val streamUrl = extractor.getStreamUrlFromKwik(video.videoUrl)
-                streamUrl to Headers.headersOf("referer", "https://kwik.cx")
+                streamUrl to Headers.headersOf("referer", "https://kwik.cx/")
             }
 
             return Video(


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

This is just a temporary fix, while HLS on the extension will work fine