### PR TITLE
fix(lib/streamwish-extractor): Fix streamwish-extractor redirections

### DIFF
--- a/lib/streamwish-extractor/src/main/java/eu/kanade/tachiyomi/lib/streamwishextractor/StreamWishExtractor.kt
+++ b/lib/streamwish-extractor/src/main/java/eu/kanade/tachiyomi/lib/streamwishextractor/StreamWishExtractor.kt
@@ -5,13 +5,13 @@ import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.util.asJsoup
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
+import org.jsoup.Jsoup
 
 class StreamWishExtractor(private val client: OkHttpClient, private val headers: Headers) {
     private val playlistUtils by lazy { PlaylistUtils(client, headers) }
@@ -21,38 +21,58 @@ class StreamWishExtractor(private val client: OkHttpClient, private val headers:
 
     fun videosFromUrl(url: String, videoNameGen: (String) -> String = { quality -> "StreamWish - $quality" }): List<Video> {
 
-        val doc = client.newCall(GET(getEmbedUrl(url), headers)).execute().asJsoup()
+        val id = getEmbedId(url)
+        for (domain in DOMAINS) {
+            val fullUrl = if (id.startsWith("https://")) id else "https://$domain/$id"
+            try {
 
-        val scriptBody = doc.selectFirst("script:containsData(m3u8)")?.data()
-            ?.let { script ->
-                if (script.contains("eval(function(p,a,c")) {
-                    JsUnpacker.unpackAndCombine(script)
-                } else {
-                    script
+                val response = client.newCall(GET(fullUrl, headers)).execute()
+                if (!response.isSuccessful) continue
+
+                val body = response.body.string()
+                if (body.isEmpty()) continue
+                val doc = Jsoup.parse(body)
+
+                val scriptBody = doc.selectFirst("script:containsData(m3u8)")?.data()
+                    ?.let { script ->
+                        if (script.contains("eval(function(p,a,c")) {
+                            JsUnpacker.unpackAndCombine(script)
+                        } else {
+                            script
+                        }
+                    }
+
+                val masterUrl = scriptBody?.let {
+                    M3U8_REGEX.find(it)?.value
                 }
+
+                if (masterUrl != null) {
+                    val subtitleList = extractSubtitles(scriptBody)
+
+                    return playlistUtils.extractFromHls(
+                        playlistUrl = masterUrl,
+                        referer = "https://${fullUrl.toHttpUrl().host}/",
+                        videoNameGen = videoNameGen,
+                        subtitleList = playlistUtils.fixSubtitles(subtitleList),
+                    )
+                }
+            } catch (e: Exception) {
+                if (id.startsWith("https://")) return emptyList()
             }
-        val masterUrl = scriptBody?.let {
-            M3U8_REGEX.find(it)?.value
         }
-            ?: return emptyList()
 
-        val subtitleList = extractSubtitles(scriptBody)
-
-        return playlistUtils.extractFromHls(
-            playlistUrl = masterUrl,
-            referer = "https://${url.toHttpUrl().host}/",
-            videoNameGen = videoNameGen,
-            subtitleList = playlistUtils.fixSubtitles(subtitleList),
-        )
+        return emptyList()
     }
 
-    private fun getEmbedUrl(url: String): String {
-        return if (url.contains("/f/")) {
-            val videoId = url.substringAfter("/f/")
-            "https://streamwish.com/$videoId"
-        } else {
-            url
-        }
+    private fun getEmbedId(url: String): String {
+        val regex = Regex(""".*/(?:e|f|d)/([a-zA-Z0-9]+)""")
+        val match = regex.find(url)
+
+        val id = match?.groupValues?.get(1)
+            ?: return url
+
+        // Prevent redirect
+        return id
     }
 
     private fun extractSubtitles(script: String): List<Track> {
@@ -78,4 +98,9 @@ class StreamWishExtractor(private val client: OkHttpClient, private val headers:
 
     private val M3U8_REGEX = Regex("""https[^"]*m3u8[^"]*""")
     private val FIX_TRACKS_REGEX = Regex("""(?<!["])(file|kind|label)(?!["])""")
+    private val DOMAINS = listOf(
+        "streamwish.com",
+        "niramirus.com",
+        "medixiru.com"
+    )
 }


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as need ed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] Have made sure all the icons are in png format

Hi!

The current StreamWish extractor assumes that the unpacking process happens on the same domain. However, the updated site now performs a redirect to a different domain, along with an additional obfuscation step before exposing the final stream URL.

To handle this, I introduced a fallback mechanism that iterates through a list of known destination domains (including the original one for compatibility) and attempts to resolve the stream from each of them.

The .m3u8 extraction logic remains unchanged.

I tested this using `es/animeflv`, but it appears that many other extensions rely on this extractor as well.