### PR TITLE
[pt/animesgratis(Top anime)] Fix Selectors

### DIFF
--- a/src/pt/animesgratis/build.gradle
+++ b/src/pt/animesgratis/build.gradle
@@ -4,7 +4,7 @@ ext {
     extClass = '.TopAnimes'
     themePkg = 'dooplay'
     baseUrl = 'https://topanimes.net'
-    overrideVersionCode = 31
+    overrideVersionCode = 32
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/TopAnimes.kt
+++ b/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/TopAnimes.kt
@@ -101,7 +101,7 @@ class TopAnimes : DooPlay(
         }
     }
 
-    override fun episodeListSelector() = "ul.episodios > li > div.episodiotitle > a"
+    override fun episodeListSelector() = "ul.episodios > li a"
 
     override fun episodeFromElement(element: Element) = SEpisode.create().apply {
         setUrlWithoutDomain(element.attr("href"))


### PR DESCRIPTION
With the previous selector, it's not possible to find episodes of some anime series. For example: https://topanimes.net/animes/hora-de-aventura-4/. This new selector solves that problem.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] Have made sure all the icons are in png format
